### PR TITLE
retry terraform destroy

### DIFF
--- a/.ado/pipelines/templates/steps-terraform-destroy.yaml
+++ b/.ado/pipelines/templates/steps-terraform-destroy.yaml
@@ -18,6 +18,7 @@ steps:
 - task: Bash@3
   displayName: 'Terraform destroy'
   name: 'terraformdestroy'
+  retryCountOnTaskFailure: 1
   inputs:
     workingDirectory: '${{ parameters.terraformWorkingDirectory }}'
     targetType: 'inline'


### PR DESCRIPTION
Auto-retry `terraform destroy` once, using https://docs.microsoft.com/en-us/azure/devops/release-notes/2021/sprint-195-update#automatic-retries-for-a-task to prevent:

![image](https://user-images.githubusercontent.com/17407022/151308078-34251b1b-01c8-4679-892d-9fbf2fdd6dd3.png)

https://dev.azure.com/alwaysonapp/AlwaysOn/_build/results?buildId=3588&view=logs&j=ebbdc2b5-c867-5b15-f4ca-489b91c137dc&t=0507d09c-dfcd-57f4-31c1-d2e75e0ea42f&s=d8748634-2e4a-5e72-4ae2-e58baf05e264

Which is causing problems with our nightly INT deployments:

![image](https://user-images.githubusercontent.com/17407022/151308160-870301a5-d5b5-4939-b3b8-745ea1fdcc2f.png)

https://github.com/Azure/AlwaysOn/pull/944 and https://github.com/Azure/AlwaysOn-foundational/pull/34