### PR TITLE
Port Kubernetes Network Policy from online to connected

### DIFF
--- a/src/app/AlwaysOn.BackgroundProcessor/Dockerfile
+++ b/src/app/AlwaysOn.BackgroundProcessor/Dockerfile
@@ -10,6 +10,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0
 RUN apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
+
 # Create a new user group and user to run the workload as non-root
 RUN groupadd -r workload && useradd --no-log-init -r -g workload workload
 USER workload

--- a/src/app/AlwaysOn.CatalogService/Dockerfile
+++ b/src/app/AlwaysOn.CatalogService/Dockerfile
@@ -10,6 +10,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0
 RUN apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
+
 # Create a new user group and user to run the workload as non-root
 RUN groupadd -r workload && useradd --no-log-init -r -g workload workload
 USER workload

--- a/src/app/AlwaysOn.CatalogService/Program.cs
+++ b/src/app/AlwaysOn.CatalogService/Program.cs
@@ -36,7 +36,7 @@ namespace AlwaysOn.CatalogService
                 config.AddKeyPerFile(directoryPath: "/mnt/secrets-store/", optional: true, reloadOnChange: true);
 
                 var builtConfig = config.Build();
-                
+
                 // TODO: Transition Serilog AppInsights sink to use the connection string instead of Instrumentation Key, once that is fully supported
                 Log.Logger = new LoggerConfiguration()
                                     .ReadFrom.Configuration(builtConfig)

--- a/src/app/AlwaysOn.HealthService/Dockerfile
+++ b/src/app/AlwaysOn.HealthService/Dockerfile
@@ -10,6 +10,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0
 RUN apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
+
 # Create a new user group and user to run the workload as non-root
 RUN groupadd -r workload && useradd --no-log-init -r -g workload workload
 USER workload

--- a/src/app/AlwaysOn.UI/Dockerfile
+++ b/src/app/AlwaysOn.UI/Dockerfile
@@ -1,5 +1,5 @@
 # Create build environment
-FROM node:17.6.0 as build-env
+FROM node:17.8.0 as build-env
 
 # enable node 17 support for vue-cli
 ENV NODE_OPTIONS=--openssl-legacy-provider

--- a/src/app/AlwaysOn.UI/README.md
+++ b/src/app/AlwaysOn.UI/README.md
@@ -1,8 +1,8 @@
 # UI Application
 
-We decided to build a simple user interface application for the Azure Mission-Critical reference implementation, which surfaces the API functionality to end users and also demonstrates how a different type of workload can be deployed to the cluster.
+We decided to build a simple user interface application for Azure Mission-Critical, which surfaces the API functionality to end users and also demonstrates how a different type of workload can be deployed to the cluster.
 
-It's a single-page application (SPA), built with the Vue.js framework, which runs entirely in the web browser and calls the workload APIs directly.
+It's a single-page application (SPA), built with the Vue.js framework, which runs entirely in the web browser and calls the Azure Mission-Critical APIs directly.
 
 ## How to run
 
@@ -39,8 +39,6 @@ docker build -t aoui .
 docker run -p 8080:80 aoui
 ```
 
-
-
 ## Configuration
 
 Configuration is handled through a static `config.js` file, which is linked directly to the page in `index.html`:
@@ -62,14 +60,14 @@ Alternatively, you could make the config object part of the compiled app code an
 
 Settings to configure:
 
-* `window.API_URL` = URL of the API root which will be used, **without the trailing "/"**. For localhost this will be something like: *http://localhost:5000/api*, for cloud environment it will be: */api* (because the UI runs on the same domain as the API). This can also be the absolute URL of a published API, only make sure that no firewall and CORS restriction are in place.
+* `window.API_URL` = URL of the API root which will be used, **without the trailing "/"**. For localhost this will be something like: `http://localhost:5000/api`, for cloud environment it will be: */api* (because the UI runs on the same domain as the API). This can also be the absolute URL of a published API, only make sure that no firewall and CORS restriction are in place.
 * `window.APPLICATIONINSIGHTS_CONNECTION_STRING` = Connection string for the Application Insights instance to be used.
 
 ## Implementation notes
 
 ### CORS
 
-Since this is a single-page application, running in the browser, it requires CORS (Cross-Origin Resource Sharing) to be enabled on the API, for cases when it's not running on the same root URL. The sample application is set up in a way that it doesn't need CORS (UI running on `/` with API running on `/api`), but on localhost, this might not be the case (UI running on `localhost:8080` and API on `localhost:5000` which are considered different origins).
+Since this is a single-page application, running in the browser, it requires CORS (Cross-Origin Resource Sharing) to be enabled on the API, for cases when it's not running on the same root URL. The Azure Mission-Critical application is set up in a way that it doesn't need CORS (UI running on `/` with API running on `/api`), but on localhost, this might not be the case (UI running on `localhost:8080` and API on `localhost:5000` which are considered different origins).
 
 *Startup.cs*
 
@@ -115,7 +113,7 @@ For demonstration purposes, the UI application is surfacing these error codes to
 
 Following the security principle of not sharing unnecessary debug information with the client, the CatalogService API provides only the Correlation ID in the failed response and doesn't share the failure reason (like an exception message).
 
-```
+```console
 Error in processing. Correlation ID: XXXXXXXXXXXXXXXXXXXXXX.
 ```
 
@@ -124,7 +122,6 @@ With this ID (and with the help of the `X-Server-Location` header) an operator i
 ### Data validation
 
 The UI is currently not performing any data validation when sending requests. But invalid data will result in a 400 Bad Request response which will cause the error banner to indicate failure.
-
 
 ## Security
 

--- a/src/app/AlwaysOn.UI/public/config.js
+++ b/src/app/AlwaysOn.UI/public/config.js
@@ -1,5 +1,5 @@
 // Use these values for local development.
 // This whole file will be replaced during deployment, with environment appropriate values.
 window.API_URL = "http://localhost:5000"; // without the trailing "/"
-window.APPLICATIONINSIGHTS_CONNECTION_STRING  = "";
-window.VERSION_LABEL = "local" 
+window.APPLICATIONINSIGHTS_CONNECTION_STRING = "";
+window.VERSION_LABEL = "local"

--- a/src/app/README.md
+++ b/src/app/README.md
@@ -1,6 +1,6 @@
 # Sample Application
 
-The Azure Mission-Critical reference implementations use a simple web shop catalog application where end users can browse through a catalog of items, see details of an item, and post ratings and comments for items. Although fairly straight forward, this application enables the Reference Implementation to demonstrate the asynchronous processing of requests and how to achieve high throughput within a solution. The application consists of three components and is implemented in .NET Core and hosted on Azure Kubernetes Service.
+The Azure Mission-Critical reference implementation uses a simple web shop catalog application where end users can browse through a catalog of items, see details of an item, and post ratings and comments for items. Although fairly straight forward, this application enables the [Reference Implementation](/docs/reference-implementation/README.md) to demonstrate the asynchronous processing of requests and how to achieve high throughput within a solution. The application consists of three components and is implemented in .NET Core and hosted on Azure Kubernetes Service.
 
 See [Application Design](/docs/reference-implementation/AppDesign-Application-Design.md) for more details about the application.
 
@@ -25,9 +25,23 @@ The UI is compiled in the CI pipeline and uploaded to Azure Storage accounts in 
 
 ## Helm Charts
 
-The `/src/app/charts` directory contains individual Helm charts for each of the application components like CatalogService, BackgroundProcessor and HealthService. Helm is used to package the YAML manifests needed to deploy the individual components together including their deployment, services as well as the auto-scaling (HPA) configuration.
+The `/src/app/charts` directory contains individual Helm charts for each of the application components like CatalogService, BackgroundProcessor and HealthService. Helm is used to package the YAML manifests needed to deploy the individual components together including their deployment, services as well as the auto-scaling (HPA) configuration. Each Helm chart contains a `values.yaml` file that contains default values and is used as an argument reference.
 
-These Helm charts are currently not uploaded into a Helm registry, they're applied directly via Helm via an [Azure DevOps pipeline](/docs/reference-implementation/DeployAndTest-DevOps-Design-Decisions.md) from within the repository.
+These workload Helm charts used in Azure Mission-Critical are currently not uploaded into a Helm registry, they're applied directly via Helm via an [Azure DevOps pipeline](/docs/reference-implementation/DeployAndTest-DevOps-Design-Decisions.md) from within the repository.
+
+### Security Context
+
+All Helm charts contain foundational security measures following K8s best practices. These security measures are:
+
+* `readOnlyFilesystem` The root filesystem `/` in each container is set to read-only. This is to prevent the container from accidentally writing to the host filesystem. Directories that require read-write access are mounted as volumes.
+* `privileged` All containers are set to run as **non-privileged**. Running a container as privileged gives all capabilities to the container, and it also lifts all the limitations enforced by the device cgroup controller.
+* `allowPrivilegeEscalation` Prevents inside of a container to gain more privileges than its parent process.
+
+These security measures are also configured for 3rd-party containers and helm charts (i.e. cert-manager) when possible and audited by Azure Policy.
+
+### Network Policy
+
+Each of our workload Helm charts contains foundational Network Policies. These policies are enabled by default and can be disabled per chart via `.Values.networkpolicy.enabled`. The `CatalogService` contains a `default-deny` rule that denies all traffic in the `workload` namespace, that is not explicitly allowed. See the individual workload readme for more details.
 
 ---
 

--- a/src/app/charts/backgroundprocessor/templates/networkpolicy.yaml
+++ b/src/app/charts/backgroundprocessor/templates/networkpolicy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.networkPolicy.enabled }}
+# Network policy to allow egress / outbound traffic from the workload.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}-allow-egress-traffic
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  egress:
+  - to:
+    - ipBlock:
+        cidr: {{ .Values.networkPolicy.egressRange | default "0.0.0.0/0" }} 
+  policyTypes:
+  - Egress
+---
+# Network policy to allow dns egress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}-allow-egress-dns
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP # UDP/53 allows DNS traffic
+      port: 53
+    - protocol: TCP # TCP/53 allows DNS traffic
+      port: 53
+  policyTypes:
+  - Egress
+{{- end }}

--- a/src/app/charts/backgroundprocessor/values.yaml
+++ b/src/app/charts/backgroundprocessor/values.yaml
@@ -2,9 +2,16 @@ container:
   containerimage: "OVERWRITE.acr.io/alwayson/backgroundprocessor:1234" # Container Image Name
   pullPolicy: "IfNotPresent" # Container Image Pull Policy. Using IfNotPresent to enable pod starts even if ACR cannot be reached and image was pulled on the node previously
 
-scale:
-  minReplicas: 2 # Min Replicas
-  maxReplicas: 8 # Max Replicas
+scale: # Horizontal Pod Autoscaler (HPA) configuration
+  minReplicas: 2 # Min. number of replicas used for HPA
+  maxReplicas: 8 # Max. number of replicas used for HPA
+
+# Note! When disabling Network Policy for this helm chart,
+# make sure to disable Network Policy for the CatalogService as well
+# as it contains a default-deny policy.
+networkPolicy:
+  enabled: true # Enable Network Policy
+  egressRange: "0.0.0.0/0" # CIDR range for allowed egress traffic
 
 azure:
   region: "East US 2"

--- a/src/app/charts/catalogservice/templates/ingress.yaml
+++ b/src/app/charts/catalogservice/templates/ingress.yaml
@@ -30,6 +30,7 @@ metadata:
   {{ toYaml .Values.ingress.annotations | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: nginx
   tls:
   - hosts:
     - {{ .Values.workload.domainname }}

--- a/src/app/charts/catalogservice/templates/networkpolicy.yaml
+++ b/src/app/charts/catalogservice/templates/networkpolicy.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.networkPolicy.enabled }}
+# Default Network Policy applied to the workload. 
+# Denies ingress and egress that is not explicitly allowed.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}-deny-all
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+# Network Policy to allow ingress traffic from * on Port 80 to the cert-manager HTTP issuer.
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ .Chart.Name }}-allow-cert-manager-resolver-ingress
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+spec:
+  podSelector:
+    matchLabels:
+      acme.cert-manager.io/http01-solver: "true"
+  ingress:
+  - from: []
+    ports:
+    - port: 8089 # default port for cm-acme-http-solve
+---
+# Network Policy to allow ingress traffic from * to the workload.
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ .Chart.Name }}-allow-ingress
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+    ports:
+    - port: {{ .Values.workload.port | default 8080 }}
+---
+# Network policy to allow egress / outbound traffic from the workload.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}-allow-egress-traffic
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  egress:
+  - to:
+    - ipBlock:
+        cidr: {{ .Values.networkPolicy.egressRange | default "0.0.0.0/0" }} 
+  policyTypes:
+  - Egress
+---
+# Network policy to allow dns egress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}-allow-egress-dns
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP # UDP/53 allows DNS traffic
+      port: 53
+    - protocol: TCP # TCP/53 allows DNS traffic
+      port: 53
+  policyTypes:
+  - Egress
+{{- end }}

--- a/src/app/charts/catalogservice/values.yaml
+++ b/src/app/charts/catalogservice/values.yaml
@@ -9,14 +9,17 @@ workload:
     port: 80 # Service Port (not used for Ingress)
     type: "ClusterIP" # Service Type (default ClusterIP)
 
-scale:
-  minReplicas: 3 # Min Replicas
-  maxReplicas: 20 # Max Replicas
+scale: # Horizontal Pod Autoscaler (HPA) configuration
+  minReplicas: 3 # Min. number of replicas used for HPA
+  maxReplicas: 20 # Max. number of replicas used for HPA
 
 ingress:
   annotations:
     cert-manager.io/cluster-issuer: "cert-manager-alwayson"
-    kubernetes.io/ingress.class: nginx
+
+networkPolicy:
+  enabled: true # Enable Network Policy (contains a default-deny policy)
+  egressRange: "0.0.0.0/0" # CIDR range for allowed egress traffic
 
 azure:
   frontdoorid: "" # Azure Front Door Header ID (blank = disabled)

--- a/src/app/charts/healthservice/templates/networkpolicy.yaml
+++ b/src/app/charts/healthservice/templates/networkpolicy.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.networkPolicy.enabled }}
+# Network Policy to allow ingress traffic from * to the workload.
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ .Chart.Name }}-allow-ingress
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  ingress:
+  - from: []
+    ports:
+    - port: {{ .Values.workload.port | default 8080 }}
+---
+# Network policy to allow egress / outbound traffic from the workload.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}-allow-egress-traffic
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  egress:
+  - to:
+    - ipBlock:
+        cidr: {{ .Values.networkPolicy.egressRange | default "0.0.0.0/0" }} 
+  policyTypes:
+  - Egress
+---
+# Network policy to allow dns egress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Chart.Name }}-allow-egress-dns
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP # UDP/53 allows DNS traffic
+      port: 53
+    - protocol: TCP # TCP/53 allows DNS traffic
+      port: 53
+  policyTypes:
+  - Egress
+{{- end }}

--- a/src/app/charts/healthservice/values.yaml
+++ b/src/app/charts/healthservice/values.yaml
@@ -10,5 +10,11 @@ workload:
 
 replicas: 3
 
+# Note! When disabling Network Policy for this helm chart,
+# make sure to disable Network Policy for the CatalogService as well
+# as it contains a default-deny policy.
+networkPolicy:
+  enabled: true # Enable Network Policy
+
 azure:
   region: "East US 2"


### PR DESCRIPTION
This PR ports the existing Network Policy implementation from Azure Mission-Critical-Online to Azure Mission-Critical-Connected.

See https://github.com/Azure/Mission-Critical-Online/pull/46 for more.