### PR TITLE
Port `ingress-nginx` configuration changes and Helm namespace creation from online

### DIFF
--- a/.ado/pipelines/config/configuration.yaml
+++ b/.ado/pipelines/config/configuration.yaml
@@ -11,7 +11,7 @@ variables:
 - name: 'helmVersion'         # helm package manager version
   value: 'v3.8.1'
 - name: 'ingressNginxVersion' # nginx ingress controller helm chart version
-  value: '4.0.18'
+  value: '4.1.0'
 - name: 'certManagerVersion'  # cert-manager helm chart version
   value: 'v1.8.0'
 - name: 'dotnetSdkVersion'    # dotnet sdk version

--- a/.ado/pipelines/templates/jobs-configuration.yaml
+++ b/.ado/pipelines/templates/jobs-configuration.yaml
@@ -39,15 +39,10 @@ jobs:
           helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
           helm repo update
 
-          $ingressNamespace = "ingress-nginx"
-
-          echo "*** Create namespace '$ingressNamespace' on AKS cluster $aksClusterName via kubectl"
-          kubectl create namespace $ingressNamespace  `
-                    --dry-run=client --output yaml | kubectl apply -f -
-
           # Deploy helm chart for ingress-nginx using a custom load balancer ip and resource group
+          $ingressNamespace = "ingress-nginx"
           helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx `
-                --namespace $ingressNamespace `
+                --namespace $ingressNamespace --create-namespace `
                 --values src/config/ingress-nginx/values.helm.yaml `
                 --set controller.service.loadBalancerIP="$aksIngressIp" `
                 --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-resource-group"="$aksClusterResourceGroup" `
@@ -108,14 +103,9 @@ jobs:
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/$(certManagerVersion)/cert-manager.crds.yaml
 
           $certManagerNamespace = "cert-manager"
-
-          echo "*** Create namespace '$certManagerNamespace' on AKS cluster $aksClusterName via kubectl"
-          kubectl create namespace $certManagerNamespace `
-                    --dry-run=client --output yaml | kubectl apply -f -
-
-          echo "*** Setting up cert-manager ClusterIssuer with Let's Encrypt"
+          echo "*** Setting up cert-manager ClusterIssuer with Let's Encrypt in namespace $certManagerNamespace"
           helm upgrade --install cert-manager-config src/config/cert-manager/chart/cert-manager-config`
-                       --namespace $certManagerNamespace `
+                       --namespace $certManagerNamespace --create-namespace `
                        --set letsencrypt.contactEmail="$(contactEmail)"
 
           echo "*** Installing cert-manager via helm on $aksClusterName"
@@ -152,12 +142,6 @@ jobs:
           # load AKS cluster credentials
           az aks get-credentials --name $aksClusterName --resource-group $aksClusterResourceGroup --overwrite-existing
 
-          echo "*** Create namespace $(workloadNamespace) on AKS cluster $aksClusterName via kubectl"
-          kubectl create namespace $(workloadNamespace) `
-                    --dry-run=client --output yaml | kubectl apply -f -
-
-          echo "*** Configuring CSI secret driver on $aksClusterName via helm"
-
           # Gather Azure KeyVault name from terraform artifact
           $keyVaultName = $stamp.key_vault_name
           echo "*** Retrieved Key Vault name $keyVaultName"
@@ -169,9 +153,9 @@ jobs:
                                                    --query "identityProfile.kubeletidentity.clientId" --output tsv)
 
           echo "*** Retrieved Kubelet clientId $kubeletIdentityClientId for cluster $clusterName"
-
+          echo "*** Configuring CSI secret driver on $aksClusterName via helm"
           helm upgrade --install csi-secrets-driver src/config/csi-secrets-driver/chart/csi-secrets-driver-config `
-                        --namespace "$(workloadNamespace)" `
+                        --namespace "$(workloadNamespace)" --create-namespace `
                         --set azure.tenantId=$tenantId `
                         --set azure.keyVaultName="$keyVaultName" `
                         --set azure.managedIdentityClientId="$kubeletIdentityClientId" `

--- a/.ado/pipelines/templates/jobs-workload-deploy.yaml
+++ b/.ado/pipelines/templates/jobs-workload-deploy.yaml
@@ -43,7 +43,7 @@ jobs: # using jobs so they each run in parallel
             # Apply workload worker helm chart
             echo  "*** Deploy healthservice to $aksClusterName (in $aksClusterResourceGroup) via helm chart"
             helm upgrade --install healthservice-workload src/app/charts/healthservice `
-                          --namespace $(workloadNamespace) `
+                          --namespace $(workloadNamespace) --create-namespace `
                           --set containerimage="$fullContainerImageName" `
                           --set azure.region="$region" `
                           ${{ parameters.additionalHelmArguments }}
@@ -120,7 +120,8 @@ jobs: # using jobs so they each run in parallel
             echo "*** Deploy workload CatalogService to $aksClusterName (in $aksClusterResourceGroup) via helm chart"
             echo "*** Using container image $fullContainerImageName"
 
-            helm upgrade --install workload-catalogservice src/app/charts/catalogservice --namespace "$(workloadNamespace)" `
+            helm upgrade --install workload-catalogservice src/app/charts/catalogservice `
+                         --namespace "$(workloadNamespace)" --create-namespace `
                          --set azure.frontdoorid="$frontDoorId" `
                          --set azure.region="$region" `
                          --set azure.baseurl="$frontDoorFqdn" `
@@ -195,7 +196,7 @@ jobs: # using jobs so they each run in parallel
             # Apply workload BackgroundProcessor helm chart
             echo  "*** Deploy workload BackgroundProcessor to $aksClusterName (in $aksClusterResourceGroup) via helm chart"
             helm upgrade --install workload-backgroundprocessor src/app/charts/backgroundprocessor `
-                         --namespace $(workloadNamespace) `
+                         --namespace $(workloadNamespace) --create-namespace `
                          --set containerimage="$fullContainerImageName" `
                          --set azure.region="$region" `
                          ${{ parameters.additionalHelmArguments }}

--- a/src/config/cert-manager/chart/cert-manager-config/templates/cert-manager.yaml
+++ b/src/config/cert-manager/chart/cert-manager-config/templates/cert-manager.yaml
@@ -1,7 +1,12 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: cert-manager-alwayson
+  name: {{ .Chart.Name }}-alwayson
+  labels:
+    app: {{ .Chart.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 spec:
   acme:
     # The ACME server URL

--- a/src/config/cert-manager/chart/cert-manager-config/templates/cert-manager.yaml
+++ b/src/config/cert-manager/chart/cert-manager-config/templates/cert-manager.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: {{ .Chart.Name }}-alwayson
+  name: {{ .Chart.Name }}
   labels:
     app: {{ .Chart.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/src/config/ingress-nginx/values.helm.yaml
+++ b/src/config/ingress-nginx/values.helm.yaml
@@ -23,8 +23,9 @@ controller:
         prometheus.io/scrape: "true"
         prometheus.io/port: "10254"
   service:
-    type:        LoadBalancer
-    enableHttp:  true # enable plain http (req. for cert-manager)
+    externalTrafficPolicy: "Local" # denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints.
+    type: LoadBalancer
+    enableHttp: true # enable plain http (req. for cert-manager)
     enableHttps: true  # enable https listener
   config:
     # Use a custom, more structured logging format


### PR DESCRIPTION
This PR ports changes made in [Mission-Critical-Online](https://github.com/Azure/Mission-Critical-Online) PRs https://github.com/Azure/Mission-Critical-Online/pull/307 and https://github.com/Azure/Mission-Critical-Online/pull/309.

* [Configure ingress-nginx externalTrafficPolicy to fix issues #309](https://github.com/Azure/Mission-Critical-Online/pull/309)
  This bumps `ingress-nginx` from `4.0.18` to `4.1.0` and sets `.spec.externalTrafficPolicy` to `Local` to fix an issue that recently affected all ingress traffic on our clusters. See https://github.com/Azure/AKS/issues/2903
* [Simplify helm chart installation #307](https://github.com/Azure/Mission-Critical-Online/pull/307)
  Replaces the current approach of creating namespaces via `kubectl apply` with `helm upgrade ... --create-namespace`.
