### PR TITLE
Fix public key used in cloud-init config

### DIFF
--- a/src/infra/build-agents/cloudinit_buildagents.conf
+++ b/src/infra/build-agents/cloudinit_buildagents.conf
@@ -64,7 +64,37 @@ apt:
                 -----END PGP PUBLIC KEY BLOCK-----
         kubernetes:
             source: "deb http://apt.kubernetes.io/ kubernetes-xenial main"
-            keyid: 7F92E05B31093BEF5A3C2D38FEEA9169307EA071
+            key: |
+                -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+                xsBNBGKItdQBCADWmKTNZEYWgXy73FvKFY5fRro4tGNa4Be4TZW3wZpct9Cj8Ejy
+                kU7S9EPoJ3EdKpxFltHRu7QbDi6LWSNA4XxwnudQrYGxnxx6Ru1KBHFxHhLfWsvF
+                cGMwit/znpxtIt9UzqCm2YTEW5NUnzQ4rXYqVQK2FLG4weYJ5bKwkY+ZsnRJpzxd
+                HGJ0pBiqwkMT8bfQdJymUBown+SeuQ2HEqfjVMsIRe0dweD2PHWeWo9fTXsz1Q5a
+                biGckyOVyoN9//DgSvLUocUcZsrWvYPaN+o8lXTO3GYFGNVsx069rxarkeCjOpiQ
+                OWrQmywXISQudcusSgmmgfsRZYW7FDBy5MQrABEBAAHNUVJhcHR1cmUgQXV0b21h
+                dGljIFNpZ25pbmcgS2V5IChjbG91ZC1yYXB0dXJlLXNpZ25pbmcta2V5LTIwMjIt
+                MDMtMDctMDhfMDFfMDEucHViKcLAYgQTAQgAFgUCYoi11AkQtT3IDRPt7wUCGwMC
+                GQEAAMGoCAB8QBNIIN3Q2D3aahrfkb6axd55zOwR0tnriuJRoPHoNuorOpCv9aWM
+                MvQACNWkxsvJxEF8OUbzhSYjAR534RDigjTetjK2i2wKLz/kJjZbuF4ZXMynCm40
+                eVm1XZqU63U9XR2RxmXppyNpMqQO9LrzGEnNJuh23icaZY6no12axymxcle/+SCm
+                da8oDAfa0iyA2iyg/eU05buZv54MC6RB13QtS+8vOrKDGr7RYp/VYvQzYWm+ck6D
+                vlaVX6VB51BkLl23SQknyZIJBVPm8ttU65EyrrgG1jLLHFXDUqJ/RpNKq+PCzWiy
+                t4uy3AfXK89RczLu3uxiD0CQI0T31u/IzsBNBGKItdQBCADIMMJdRcg0Phv7+CrZ
+                z3xRE8Fbz8AN+YCLigQeH0B9lijxkjAFr+thB0IrOu7ruwNY+mvdP6dAewUur+pJ
+                aIjEe+4s8JBEFb4BxJfBBPuEbGSxbi4OPEJuwT53TMJMEs7+gIxCCmwioTggTBp6
+                JzDsT/cdBeyWCusCQwDWpqoYCoUWJLrUQ6dOlI7s6p+iIUNIamtyBCwb4izs27Hd
+                EpX8gvO9rEdtcb7399HyO3oD4gHgcuFiuZTpvWHdn9WYwPGM6npJNG7crtLnctTR
+                0cP9KutSPNzpySeAniHx8L9ebdD9tNPCWC+OtOcGRrcBeEznkYh1C4kzdP1ORm5u
+                pnknABEBAAHCwF8EGAEIABMFAmKItdQJELU9yA0T7e8FAhsMAABJmAgAhRPk/dFj
+                71bU/UTXrkEkZZzE9JzUgan/ttyRrV6QbFZABByf4pYjBj+yLKw3280//JWurKox
+                2uzEq1hdXPedRHICRuh1Fjd00otaQ+wGF3kY74zlWivB6Wp6tnL9STQ1oVYBUv7H
+                hSHoJ5shELyedxxHxurUgFAD+pbFXIiK8cnAHfXTJMcrmPpC+YWEC/DeqIyEcNPk
+                zRhtRSuERXcq1n+KJvMUAKMD/tezwvujzBaaSWapmdnGmtRjjL7IxUeGamVWOwLQ
+                bUr+34MwzdeJdcL8fav5LA8Uk0ulyeXdwiAK8FKQsixI+xZvz7HUs8ln4pZwGw/T
+                pvO9cMkHogtgzQ==
+                =wslW
+                -----END PGP PUBLIC KEY BLOCK-----
 
 # Install packages via apt. To add packages it might be required to add additional sources above.
 packages:

--- a/src/infra/build-agents/cloudinit_buildagents.conf
+++ b/src/infra/build-agents/cloudinit_buildagents.conf
@@ -66,7 +66,8 @@ apt:
             source: "deb http://apt.kubernetes.io/ kubernetes-xenial main"
             key: |
                 -----BEGIN PGP PUBLIC KEY BLOCK-----
-
+                Version: GnuPG v1.4.7 (GNU/Linux)
+                
                 xsBNBGKItdQBCADWmKTNZEYWgXy73FvKFY5fRro4tGNa4Be4TZW3wZpct9Cj8Ejy
                 kU7S9EPoJ3EdKpxFltHRu7QbDi6LWSNA4XxwnudQrYGxnxx6Ru1KBHFxHhLfWsvF
                 cGMwit/znpxtIt9UzqCm2YTEW5NUnzQ4rXYqVQK2FLG4weYJ5bKwkY+ZsnRJpzxd

--- a/src/infra/build-agents/cloudinit_buildagents.conf
+++ b/src/infra/build-agents/cloudinit_buildagents.conf
@@ -63,7 +63,7 @@ apt:
                 =J6gs
                 -----END PGP PUBLIC KEY BLOCK-----
         kubernetes:
-            source: "deb http://apt.kubernetes.io/ kubernetes-xenial main"
+            source: "deb https://packages.cloud.google.com/apt/ kubernetes-xenial main"
             key: | 
                 -----BEGIN PGP PUBLIC KEY BLOCK-----
 

--- a/src/infra/build-agents/cloudinit_buildagents.conf
+++ b/src/infra/build-agents/cloudinit_buildagents.conf
@@ -65,7 +65,7 @@ apt:
         kubernetes:
             source: "deb http://apt.kubernetes.io/ kubernetes-xenial main"
             keyserver: "hkp://keyserver.ubuntu.com:80"
-            keyid: BA07F4FB
+            keyid: 54A647F9048D5688D7DA2ABE6A030B21BA07F4FB
         docker:
             source: "deb https://download.docker.com/linux/ubuntu bionic stable"
             keyserver: "hkp://keyserver.ubuntu.com:80"

--- a/src/infra/build-agents/cloudinit_buildagents.conf
+++ b/src/infra/build-agents/cloudinit_buildagents.conf
@@ -67,10 +67,10 @@ apt:
             keyserver: "hkp://keyserver.ubuntu.com:80"
             keyid: BA07F4FB
         docker:
-          arches: amd64
-          source: "deb https://download.docker.com/linux/ubuntu bionic stable"
-          keyserver: "hkp://keyserver.ubuntu.com:80"
-          keyid: 0EBFCD88
+            arches: amd64
+            source: "deb https://download.docker.com/linux/ubuntu bionic stable"
+            keyserver: "hkp://keyserver.ubuntu.com:80"
+            keyid: 0EBFCD88
 # Install packages via apt. To add packages it might be required to add additional sources above.
 packages:
  - unzip

--- a/src/infra/build-agents/cloudinit_buildagents.conf
+++ b/src/infra/build-agents/cloudinit_buildagents.conf
@@ -64,39 +64,13 @@ apt:
                 -----END PGP PUBLIC KEY BLOCK-----
         kubernetes:
             source: "deb http://apt.kubernetes.io/ kubernetes-xenial main"
-            key: |
-                -----BEGIN PGP PUBLIC KEY BLOCK-----
-                Version: GnuPG v1.4.7 (GNU/Linux)
-                
-                xsBNBGKItdQBCADWmKTNZEYWgXy73FvKFY5fRro4tGNa4Be4TZW3wZpct9Cj8Ejy
-                kU7S9EPoJ3EdKpxFltHRu7QbDi6LWSNA4XxwnudQrYGxnxx6Ru1KBHFxHhLfWsvF
-                cGMwit/znpxtIt9UzqCm2YTEW5NUnzQ4rXYqVQK2FLG4weYJ5bKwkY+ZsnRJpzxd
-                HGJ0pBiqwkMT8bfQdJymUBown+SeuQ2HEqfjVMsIRe0dweD2PHWeWo9fTXsz1Q5a
-                biGckyOVyoN9//DgSvLUocUcZsrWvYPaN+o8lXTO3GYFGNVsx069rxarkeCjOpiQ
-                OWrQmywXISQudcusSgmmgfsRZYW7FDBy5MQrABEBAAHNUVJhcHR1cmUgQXV0b21h
-                dGljIFNpZ25pbmcgS2V5IChjbG91ZC1yYXB0dXJlLXNpZ25pbmcta2V5LTIwMjIt
-                MDMtMDctMDhfMDFfMDEucHViKcLAYgQTAQgAFgUCYoi11AkQtT3IDRPt7wUCGwMC
-                GQEAAMGoCAB8QBNIIN3Q2D3aahrfkb6axd55zOwR0tnriuJRoPHoNuorOpCv9aWM
-                MvQACNWkxsvJxEF8OUbzhSYjAR534RDigjTetjK2i2wKLz/kJjZbuF4ZXMynCm40
-                eVm1XZqU63U9XR2RxmXppyNpMqQO9LrzGEnNJuh23icaZY6no12axymxcle/+SCm
-                da8oDAfa0iyA2iyg/eU05buZv54MC6RB13QtS+8vOrKDGr7RYp/VYvQzYWm+ck6D
-                vlaVX6VB51BkLl23SQknyZIJBVPm8ttU65EyrrgG1jLLHFXDUqJ/RpNKq+PCzWiy
-                t4uy3AfXK89RczLu3uxiD0CQI0T31u/IzsBNBGKItdQBCADIMMJdRcg0Phv7+CrZ
-                z3xRE8Fbz8AN+YCLigQeH0B9lijxkjAFr+thB0IrOu7ruwNY+mvdP6dAewUur+pJ
-                aIjEe+4s8JBEFb4BxJfBBPuEbGSxbi4OPEJuwT53TMJMEs7+gIxCCmwioTggTBp6
-                JzDsT/cdBeyWCusCQwDWpqoYCoUWJLrUQ6dOlI7s6p+iIUNIamtyBCwb4izs27Hd
-                EpX8gvO9rEdtcb7399HyO3oD4gHgcuFiuZTpvWHdn9WYwPGM6npJNG7crtLnctTR
-                0cP9KutSPNzpySeAniHx8L9ebdD9tNPCWC+OtOcGRrcBeEznkYh1C4kzdP1ORm5u
-                pnknABEBAAHCwF8EGAEIABMFAmKItdQJELU9yA0T7e8FAhsMAABJmAgAhRPk/dFj
-                71bU/UTXrkEkZZzE9JzUgan/ttyRrV6QbFZABByf4pYjBj+yLKw3280//JWurKox
-                2uzEq1hdXPedRHICRuh1Fjd00otaQ+wGF3kY74zlWivB6Wp6tnL9STQ1oVYBUv7H
-                hSHoJ5shELyedxxHxurUgFAD+pbFXIiK8cnAHfXTJMcrmPpC+YWEC/DeqIyEcNPk
-                zRhtRSuERXcq1n+KJvMUAKMD/tezwvujzBaaSWapmdnGmtRjjL7IxUeGamVWOwLQ
-                bUr+34MwzdeJdcL8fav5LA8Uk0ulyeXdwiAK8FKQsixI+xZvz7HUs8ln4pZwGw/T
-                pvO9cMkHogtgzQ==
-                =wslW
-                -----END PGP PUBLIC KEY BLOCK-----
-
+            keyserver: "hkp://keyserver.ubuntu.com:80"
+            keyid: BA07F4FB
+        docker:
+          arches: amd64
+          source: "deb https://download.docker.com/linux/ubuntu bionic stable"
+          keyserver: "hkp://keyserver.ubuntu.com:80"
+          keyid: 0EBFCD88
 # Install packages via apt. To add packages it might be required to add additional sources above.
 packages:
  - unzip

--- a/src/infra/build-agents/cloudinit_buildagents.conf
+++ b/src/infra/build-agents/cloudinit_buildagents.conf
@@ -94,7 +94,7 @@ apt:
                 bUr+34MwzdeJdcL8fav5LA8Uk0ulyeXdwiAK8FKQsixI+xZvz7HUs8ln4pZwGw/T
                 pvO9cMkHogtgzQ==
                 =6mRm
-            -----END PGP PUBLIC KEY BLOCK-----
+                -----END PGP PUBLIC KEY BLOCK-----
 
 # Install packages via apt. To add packages it might be required to add additional sources above.
 packages:

--- a/src/infra/build-agents/cloudinit_buildagents.conf
+++ b/src/infra/build-agents/cloudinit_buildagents.conf
@@ -64,12 +64,38 @@ apt:
                 -----END PGP PUBLIC KEY BLOCK-----
         kubernetes:
             source: "deb http://apt.kubernetes.io/ kubernetes-xenial main"
-            keyserver: "hkp://keyserver.ubuntu.com:80"
-            keyid: 8B57C5C2836F4BEB
-        docker:
-            source: "deb https://download.docker.com/linux/ubuntu bionic stable"
-            keyserver: "hkp://keyserver.ubuntu.com:80"
-            keyid: 0EBFCD88
+            key: | 
+                -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+                mQENBGKItdQBCADWmKTNZEYWgXy73FvKFY5fRro4tGNa4Be4TZW3wZpct9Cj8Ejy
+                kU7S9EPoJ3EdKpxFltHRu7QbDi6LWSNA4XxwnudQrYGxnxx6Ru1KBHFxHhLfWsvF
+                cGMwit/znpxtIt9UzqCm2YTEW5NUnzQ4rXYqVQK2FLG4weYJ5bKwkY+ZsnRJpzxd
+                HGJ0pBiqwkMT8bfQdJymUBown+SeuQ2HEqfjVMsIRe0dweD2PHWeWo9fTXsz1Q5a
+                biGckyOVyoN9//DgSvLUocUcZsrWvYPaN+o8lXTO3GYFGNVsx069rxarkeCjOpiQ
+                OWrQmywXISQudcusSgmmgfsRZYW7FDBy5MQrABEBAAG0UVJhcHR1cmUgQXV0b21h
+                dGljIFNpZ25pbmcgS2V5IChjbG91ZC1yYXB0dXJlLXNpZ25pbmcta2V5LTIwMjIt
+                MDMtMDctMDhfMDFfMDEucHViKYkBIgQTAQgAFgUCYoi11AkQtT3IDRPt7wUCGwMC
+                GQEAAMGoB/98QBNIIN3Q2D3aahrfkb6axd55zOwR0tnriuJRoPHoNuorOpCv9aWM
+                MvQACNWkxsvJxEF8OUbzhSYjAR534RDigjTetjK2i2wKLz/kJjZbuF4ZXMynCm40
+                eVm1XZqU63U9XR2RxmXppyNpMqQO9LrzGEnNJuh23icaZY6no12axymxcle/+SCm
+                da8oDAfa0iyA2iyg/eU05buZv54MC6RB13QtS+8vOrKDGr7RYp/VYvQzYWm+ck6D
+                vlaVX6VB51BkLl23SQknyZIJBVPm8ttU65EyrrgG1jLLHFXDUqJ/RpNKq+PCzWiy
+                t4uy3AfXK89RczLu3uxiD0CQI0T31u/IuQENBGKItdQBCADIMMJdRcg0Phv7+CrZ
+                z3xRE8Fbz8AN+YCLigQeH0B9lijxkjAFr+thB0IrOu7ruwNY+mvdP6dAewUur+pJ
+                aIjEe+4s8JBEFb4BxJfBBPuEbGSxbi4OPEJuwT53TMJMEs7+gIxCCmwioTggTBp6
+                JzDsT/cdBeyWCusCQwDWpqoYCoUWJLrUQ6dOlI7s6p+iIUNIamtyBCwb4izs27Hd
+                EpX8gvO9rEdtcb7399HyO3oD4gHgcuFiuZTpvWHdn9WYwPGM6npJNG7crtLnctTR
+                0cP9KutSPNzpySeAniHx8L9ebdD9tNPCWC+OtOcGRrcBeEznkYh1C4kzdP1ORm5u
+                pnknABEBAAGJAR8EGAEIABMFAmKItdQJELU9yA0T7e8FAhsMAABJmAgAhRPk/dFj
+                71bU/UTXrkEkZZzE9JzUgan/ttyRrV6QbFZABByf4pYjBj+yLKw3280//JWurKox
+                2uzEq1hdXPedRHICRuh1Fjd00otaQ+wGF3kY74zlWivB6Wp6tnL9STQ1oVYBUv7H
+                hSHoJ5shELyedxxHxurUgFAD+pbFXIiK8cnAHfXTJMcrmPpC+YWEC/DeqIyEcNPk
+                zRhtRSuERXcq1n+KJvMUAKMD/tezwvujzBaaSWapmdnGmtRjjL7IxUeGamVWOwLQ
+                bUr+34MwzdeJdcL8fav5LA8Uk0ulyeXdwiAK8FKQsixI+xZvz7HUs8ln4pZwGw/T
+                pvO9cMkHogtgzQ==
+                =6mRm
+            -----END PGP PUBLIC KEY BLOCK-----
+
 # Install packages via apt. To add packages it might be required to add additional sources above.
 packages:
  - unzip

--- a/src/infra/build-agents/cloudinit_buildagents.conf
+++ b/src/infra/build-agents/cloudinit_buildagents.conf
@@ -67,7 +67,6 @@ apt:
             keyserver: "hkp://keyserver.ubuntu.com:80"
             keyid: BA07F4FB
         docker:
-            arches: amd64
             source: "deb https://download.docker.com/linux/ubuntu bionic stable"
             keyserver: "hkp://keyserver.ubuntu.com:80"
             keyid: 0EBFCD88

--- a/src/infra/build-agents/cloudinit_buildagents.conf
+++ b/src/infra/build-agents/cloudinit_buildagents.conf
@@ -65,7 +65,7 @@ apt:
         kubernetes:
             source: "deb http://apt.kubernetes.io/ kubernetes-xenial main"
             keyserver: "hkp://keyserver.ubuntu.com:80"
-            keyid: 54A647F9048D5688D7DA2ABE6A030B21BA07F4FB
+            keyid: 8B57C5C2836F4BEB
         docker:
             source: "deb https://download.docker.com/linux/ubuntu bionic stable"
             keyserver: "hkp://keyserver.ubuntu.com:80"


### PR DESCRIPTION
Some dependencies like kubectl, docker, powershell et al are installed using cloud-init at vmss instance creation / boot time. Some dependencies are loaded from third party repositories like for example from google.

One of the public keys used has expired. This led to an error message and resulted in not installed dependencies like powershell (pwsh).

<img width="586" alt="image" src="https://user-images.githubusercontent.com/17407022/218471218-369adf52-dfcb-4413-bc67-3c92be6a094c.png">

This PR updates the cloud init configuration file used and ensures that all dependencies needed can be installed successfully during the corresponding pipeline runs. 

<img width="181" alt="image" src="https://user-images.githubusercontent.com/17407022/218471459-e231ae20-02d0-438a-97d9-2f6057712a4c.png">

See also:

```log
[..]
[   32.575852] cloud-init[1430]: Get:18 https://packages.cloud.google.com/apt kubernetes-xenial/main amd64 Packages [63.2 kB]
[..]
[   43.860404] cloud-init[2121]: The following NEW packages will be installed:
[   43.864095] cloud-init[2121]:   apt-transport-https azure-cli bridge-utils containerd dns-root-data
[   43.866294] cloud-init[2121]:   dnsmasq-base docker.io kubectl libidn11 packages-microsoft-prod pigz
[   43.866753] cloud-init[2121]:   powershell runc ubuntu-fan unzip
[..]
[   66.334593] cloud-init[2121]: Setting up powershell (7.3.2-1.deb) ...
```
