### PR TITLE
Bump WAF Managed rule set to v2.1

### DIFF
--- a/src/infra/workload/globalresources/frontdoor.tf
+++ b/src/infra/workload/globalresources/frontdoor.tf
@@ -268,7 +268,7 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "global" {
 
   managed_rule {
     type    = "Microsoft_DefaultRuleSet"
-    version = "2.0"
+    version = "2.1"
     action  = "Block"
   }
   managed_rule {


### PR DESCRIPTION
Bump rule set to latest.
v2.1 contains improvements in false positive rate detection, and other enhancements
https://learn.microsoft.com/en-us/azure/web-application-firewall/ag/application-gateway-crs-rulegroups-rules?tabs=drs21#drs-21
